### PR TITLE
Add GitHub issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name:  Bug Report
+about: Report a problem or unexpected behavior
+title: "[BUG] "
+labels: bug
+---
+
+##  Bug Description
+A clear and concise description of what the bug is.
+
+##  Steps to Reproduce
+1. Go to '...'
+2. Click on '...'
+3. See error
+
+##  Expected Behavior
+What you expected to happen.
+
+##  Screenshots / Logs
+If applicable, add screenshots or logs.
+
+##  Environment
+- OS:
+- Browser:
+- Node version:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,15 @@
+---
+name:  Feature Request
+about: Suggest a new feature or improvement
+title: "[FEATURE] "
+labels: enhancement
+---
+
+##  Feature Description
+Describe the feature clearly.
+
+##  Motivation
+Why is this feature useful?
+
+##  Additional Context
+Add screenshots, mockups, or examples if any.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+##  Summary
+Briefly explain what this PR does.
+
+##  Related Issue
+Closes #ISSUE_NUMBER
+
+##  How to Test
+Steps to test this PR.
+
+##  Screenshots (if applicable)
+Attach screenshots if UI-related.


### PR DESCRIPTION
This PR adds standardized templates for:
- Bug reports
- Feature requests
- Pull requests

These templates help contributors provide clear and consistent information.

Closes #84
